### PR TITLE
fix: eval tests makefile updates to support langsmith tracking disabled

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,4 +37,6 @@ jobs:
           pip install -r requirements.txt
 
       - name: Run tests
-        run: make run-test
+        run: |
+          make run-test
+          make eval-langsmith-tracking-disabled

--- a/Makefile
+++ b/Makefile
@@ -80,10 +80,21 @@ clean:
 
 eval: eval-strict
 
-eval-strict: .env venv/bin/activate
+eval-langsmith-tracking-disabled: eval-strict-langsmith-tracking-disabled
+
+eval-strict-langsmith-tracking-disabled: venv/bin/activate
 	@echo "Running evaluation with LLM and mock Jira responses..."
 	. venv/bin/activate && \
-	. .env && \
+	pip install --upgrade pip setuptools && \
+	pip install -r eval/requirements.txt && \
+	export PYTHONPATH=src && \
+	export DRYRUN=true && \
+	export LANGSMITH_TEST_TRACKING=false && \
+	python3 -m pytest eval/strict_match/test_strict_match.py
+
+eval-strict: venv/bin/activate
+	@echo "Running evaluation with LLM and mock Jira responses..."
+	. venv/bin/activate && \
 	pip install --upgrade pip setuptools && \
 	pip install -r eval/requirements.txt && \
 	export PYTHONPATH=src && \

--- a/README.md
+++ b/README.md
@@ -283,6 +283,11 @@ To run the tests or eval tests, you need to set up the environment variables and
       ```bash
       make eval
       ```
+    - To run the eval tests (with Langsmith tracing disabled), execute:
+      ```bash
+      make eval-langsmith-tracking-disabled
+      ```
+      *Note* - When running the Eval Tests. If not using Langsmith for tracing, the `LANGCHAIN_API_KEY' is not required.
 
 This will ensure the environment variables are loaded and the tests are executed.
 

--- a/eval/strict_match/test_strict_match.py
+++ b/eval/strict_match/test_strict_match.py
@@ -59,9 +59,6 @@ def verify_llm_settings_for_strict_eval():
   if not os.getenv("DRYRUN"):
     return False, "DRYRUN environment not set"
 
-  if not os.getenv("LANGCHAIN_API_KEY") or not os.getenv("LANGSMITH_TRACING"):
-    return False, "Missing LANGCHAIN_API_KEY or LANGSMITH_TRACING."
-
   openai_settings = [
     os.getenv("TEST_OPENAI_ENDPOINT"),
     os.getenv("TEST_OPENAI_API_KEY"),
@@ -97,7 +94,7 @@ def get_mock_settings():
         AZURE_OPENAI_ENDPOINT=os.getenv("TEST_AZURE_OPENAI_ENDPOINT"),
         AZURE_OPENAI_API_KEY=os.getenv("TEST_AZURE_OPENAI_API_KEY"),
         AZURE_OPENAI_API_VERSION=os.getenv("TEST_AZURE_OPENAI_API_VERSION"),
-        AZURE_OPENAI_DEPLOYMENT_NAME=os.getenv("TEST_AZURE_OPENAI_DEPLOYMENT_NAME"),
+        AZURE_OPENAI_DEPLOYMENT_NAME=os.getenv("TEST_AZURE_OPENAI_DEPLOYMENT_NAME") or "gpt-4o",
         # Azure or OpenAI (default is Azure)
         LLM_PROVIDER=os.getenv("TEST_LLM_PROVIDER") or "azure",
     )


### PR DESCRIPTION
# Description

Adding Makefile updates for Eval tests (langsmith tracking disabled). 

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [X] Documentation
- [X] Listed above

## Checklist

- [ ] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [X] All new and existing tests pass
