### PR TITLE
feat: publish multi-platform builds

### DIFF
--- a/.github/workflows/docker-build-push.yaml
+++ b/.github/workflows/docker-build-push.yaml
@@ -24,6 +24,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          install: true
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
@@ -37,7 +39,8 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }} # only publish when pr merged to main
+          push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+          platforms: linux/amd64,linux/arm64
           tags: ghcr.io/${{ github.repository_owner }}/jira-agntcy-agent:latest
 
       - name: Build and push Docker image (tag)
@@ -47,4 +50,5 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ghcr.io/${{ github.repository_owner }}/jira-agntcy-agent:${{ github.ref_name }}


### PR DESCRIPTION
# Description

Added the followings to the GH Action workflows:
- platforms: Specifies the architectures to build for (linux/amd64 and linux/arm64).
- docker/setup-buildx-action: Ensures Buildx is set up for multi-platform builds.
- push: Ensures the image is pushed to the registry after building.
This will create a multi-platform image that supports both linux/amd64 and linux/arm64.
